### PR TITLE
Handle SpEL for byte-array payloads

### DIFF
--- a/spring-cloud-starter-stream-processor-header-enricher/src/test/java/org/springframework/cloud/stream/app/header/enricher/processor/HeaderEnricherProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-header-enricher/src/test/java/org/springframework/cloud/stream/app/header/enricher/processor/HeaderEnricherProcessorIntegrationTests.java
@@ -56,7 +56,8 @@ public abstract class HeaderEnricherProcessorIntegrationTests {
 	protected MessageCollector collector;
 
 	protected void doTest() throws InterruptedException {
-		this.channels.input().send(MessageBuilder.withPayload("hello").setHeader("baz", "qux").build());
+		this.channels.input().send(MessageBuilder.withPayload("hello".getBytes())
+				.setHeader("baz", "qux").build());
 		Message<?> out = this.collector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
 		assertThat(out, notNullValue());
 		assertThat(out, HeaderMatcher.hasHeader("foo", equalTo("bar")));


### PR DESCRIPTION
 - Override the HeaderEnricher#transform to handle byte[] payload. (Similar to the LogSink use case).
 - extend test to emulate byte[] payload.

 Resolves #23